### PR TITLE
add name of cookbook to metadata.rb to stop Ridley complaining

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "chef-whitelist"
 maintainer       "Etsy, Inc."
 maintainer_email ""
 license          "MIT"


### PR DESCRIPTION
Ran into the following when testing this cookbook locally with chef-zero:

Ridley::Errors::MissingNameAttribute: The metadata at 'chef/cookbooks/chef-whitelist' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.

I have added the missing name attribute to the metadata.rb.
