### PR TITLE
Fix an issue with databags not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.kitchen

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,15 @@
+---
+driver:
+  name: docker
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: centos-7.0
+
+suites:
+  - name: default
+    data_bags_path: "test/integration/data_bags"
+    run_list:
+      - recipe[chef-whitelist]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,12 @@
+
+# Test that everything works if a databag is present
 if node.is_in_whitelist? "whitelist"
-  # new hawtness
+  log "New Hawtness!"
 else
-  # old boring stuff
+  raise "This is old boring stuff we should not be in here for our mocked data"
+end
+
+# Testing that something that doesnt exist doesn't fail everything
+if node.is_in_whitelist? "dont-exist"
+  raise "This wasn't found we should definitly not be in here"
 end

--- a/test/integration/data_bags/whitelist/whitelist.json
+++ b/test/integration/data_bags/whitelist/whitelist.json
@@ -1,0 +1,6 @@
+{
+  "id": "whitelist",
+  "patterns": [
+    "*"
+  ]
+}


### PR DESCRIPTION
So we are just going to use our fork since this isn't on supermarket currently and we are manually pushing it to a chef server but though this might be useful.  
- Refactors some and allows for testing (rough pass but better than nothing)
- Catches the 404 error for a databag missing and returns an empty hash so default is off
